### PR TITLE
feat: Add some eslint rules for typescript and React

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+!.eslintrc.js

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,3 +1,4 @@
 module.exports = {
-  extends: ['./packages/eslint-config-globis/base.js']
+  extends: ['airbnb/base', 'plugin:prettier/recommended'],
+  plugins: ['prettier'],
 }

--- a/packages/eslint-config-globis/index.js
+++ b/packages/eslint-config-globis/index.js
@@ -3,5 +3,11 @@ module.exports = {
   rules: {
     'import/order': ['error', { 'newlines-between': 'always' }],
     'import/prefer-default-export': 0,
+    // FixMe https://github.com/yannickcr/eslint-plugin-react/issues/1846
+    'react/button-has-type': 'off',
+    'react/jsx-filename-extension': [1, { extensions: ['.tsx'] }],
+    'react/jsx-key': ['error', { checkFragmentShorthand: true }],
+    'react/jsx-props-no-spreading': 0,
+    'react/prop-types': 0,
   },
 }

--- a/packages/eslint-config-globis/index.js
+++ b/packages/eslint-config-globis/index.js
@@ -1,5 +1,5 @@
 module.exports = {
-  extends: ['airbnb', 'airbnb/hooks', './shared.js'],
+  extends: ['airbnb', 'airbnb/hooks', './shared.js', 'prettier/react'],
   rules: {
     'import/order': ['error', { 'newlines-between': 'always' }],
     'import/prefer-default-export': 0,

--- a/packages/eslint-config-globis/index.js
+++ b/packages/eslint-config-globis/index.js
@@ -1,3 +1,7 @@
 module.exports = {
   extends: ['airbnb', 'airbnb/hooks', './shared.js'],
+  rules: {
+    'import/order': ['error', { 'newlines-between': 'always' }],
+    'import/prefer-default-export': 0,
+  },
 }

--- a/packages/eslint-config-globis/shared.js
+++ b/packages/eslint-config-globis/shared.js
@@ -4,7 +4,6 @@ module.exports = {
     'plugin:@typescript-eslint/recommended',
     'plugin:@typescript-eslint/recommended-requiring-type-checking',
     'plugin:prettier/recommended',
-    'prettier/react',
     'prettier/@typescript-eslint',
   ],
   parser: '@typescript-eslint/parser',

--- a/packages/eslint-config-globis/shared.js
+++ b/packages/eslint-config-globis/shared.js
@@ -19,6 +19,5 @@ module.exports = {
         argsIgnorePattern: '^_',
       },
     ],
-    '@typescript-eslint/prefer-interface': 'off',
   },
 }

--- a/packages/eslint-config-globis/shared.js
+++ b/packages/eslint-config-globis/shared.js
@@ -1,5 +1,8 @@
 module.exports = {
   extends: [
+    'plugin:@typescript-eslint/eslint-recommended',
+    'plugin:@typescript-eslint/recommended',
+    'plugin:@typescript-eslint/recommended-requiring-type-checking',
     'plugin:prettier/recommended',
     'prettier/react',
     'prettier/@typescript-eslint',


### PR DESCRIPTION
## TL;DR
- Remove removed `prefer-interface` rule
- Enable lint dotfile (.eslintrc.js only)
- Only lint for this repository is javascript
- Add some import rules
- Add some React rules

## check list
- [x] pass CI