### PR TITLE
chore: Add scope option to publish command

### DIFF
--- a/ship.config.js
+++ b/ship.config.js
@@ -1,5 +1,6 @@
 module.exports = {
-  publishCommand: ({ defaultCommand }) => `${defaultCommand} --access public`,
+  publishCommand: ({ defaultCommand }) =>
+    `${defaultCommand} --access public --scope=globis`,
   monorepo: {
     mainVersionFile: 'package.json',
     packagesToBump: ['packages/*'],


### PR DESCRIPTION
## TL;DR

- Add scope option to ship.js publish command
	- [Creating and publishing an Org scoped package | npm Documentation](https://docs.npmjs.com/creating-and-publishing-an-org-scoped-package#creating-an-org-scoped-package)

## Check list

- [ ] Passed CI