### PR TITLE
docs: Add eslint-config-globis to Packages Header Section

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ globis frontend standard configs.
 
 This is a mono-repository using yarn workspace.
 
+- [eslint-config-globis](packages/eslint-config-globis)
+
 ## Contributing
 
 PRs accepted.


### PR DESCRIPTION
## TL;DR

- Add eslint-config-globis to Packages Header Section

## Check list

- [x] Passed CI
- [x] Enable README link