### PR TITLE
disable @typescript-eslint/explicit-module-boundary-types

### DIFF
--- a/packages/eslint-config-globis/index.js
+++ b/packages/eslint-config-globis/index.js
@@ -9,5 +9,6 @@ module.exports = {
     'react/jsx-key': ['error', { checkFragmentShorthand: true }],
     'react/jsx-props-no-spreading': 0,
     'react/prop-types': 0,
+    '@typescript-eslint/explicit-module-boundary-types': 'off',
   },
 }


### PR DESCRIPTION
## TL;DR

we do not need check return type at default.

## How to check

- check changes

## Check list

- [x] passed CI