### PR TITLE
feat: Switch to eslint-config-airbnb-typescript

### DIFF
--- a/packages/eslint-config-globis/base.js
+++ b/packages/eslint-config-globis/base.js
@@ -1,3 +1,14 @@
 module.exports = {
-  extends: ['airbnb/base', './shared.js'],
+  overrides: [
+    {
+      // RuleSet for JavaScript
+      files: ['**/*.js', '**/*.jsx'],
+      extends: ['airbnb/base', './shared.js'],
+    },
+    {
+      // RuleSet for TypeScript
+      files: ['**/*.ts', '**/*.tsx'],
+      extends: ['airbnb-typescript/base', './shared.js'],
+    },
+  ],
 }

--- a/packages/eslint-config-globis/index.js
+++ b/packages/eslint-config-globis/index.js
@@ -1,14 +1,14 @@
 const { rules: reactRules } = require('./rules/react')
 
 module.exports = {
-  rules: {
-    ...reactRules,
-  },
   overrides: [
     {
       // RuleSet for JavaScript
       files: ['**/*.js', '**/*.jsx'],
       extends: ['airbnb', 'airbnb/hooks', './shared.js', 'prettier/react'],
+      rules: {
+        ...reactRules,
+      },
     },
     {
       // RuleSet for TypeScript
@@ -19,6 +19,9 @@ module.exports = {
         './shared.js',
         'prettier/react',
       ],
+      rules: {
+        ...reactRules,
+      },
     },
   ],
 }

--- a/packages/eslint-config-globis/index.js
+++ b/packages/eslint-config-globis/index.js
@@ -1,11 +1,24 @@
+const { rules: reactRules } = require('./rules/react')
+
 module.exports = {
-  extends: ['airbnb', 'airbnb/hooks', './shared.js', 'prettier/react'],
   rules: {
-    // FixMe https://github.com/yannickcr/eslint-plugin-react/issues/1846
-    'react/button-has-type': 'off',
-    'react/jsx-filename-extension': ['error', { extensions: ['.tsx'] }],
-    'react/jsx-key': ['error', { checkFragmentShorthand: true }],
-    'react/jsx-props-no-spreading': 'off',
-    'react/prop-types': 'off',
+    ...reactRules,
   },
+  overrides: [
+    {
+      // RuleSet for JavaScript
+      files: ['**/*.js', '**/*.jsx'],
+      extends: ['airbnb', 'airbnb/hooks', './shared.js', 'prettier/react'],
+    },
+    {
+      // RuleSet for TypeScript
+      files: ['**/*.ts', '**/*.tsx'],
+      extends: [
+        'airbnb-typescript',
+        'airbnb/hooks',
+        './shared.js',
+        'prettier/react',
+      ],
+    },
+  ],
 }

--- a/packages/eslint-config-globis/package.json
+++ b/packages/eslint-config-globis/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@typescript-eslint/eslint-plugin": "4.1.0",
     "@typescript-eslint/parser": "4.1.0",
-    "eslint-config-airbnb": "18.2.0",
+    "eslint-config-airbnb-typescript": "10.0.0",
     "eslint-config-prettier": "6.11.0",
     "eslint-plugin-import": "2.22.0",
     "eslint-plugin-jsx-a11y": "6.3.1",

--- a/packages/eslint-config-globis/rules/base.js
+++ b/packages/eslint-config-globis/rules/base.js
@@ -1,0 +1,18 @@
+const rules = {
+  // FixMe https://github.com/benmosher/eslint-plugin-import/issues/1615
+  'import/extensions': [
+    'error',
+    'ignorePackages',
+    {
+      js: 'never',
+      jsx: 'never',
+      mjs: 'never',
+      ts: 'never',
+      tsx: 'never',
+    },
+  ],
+  'import/order': ['error', { 'newlines-between': 'always' }],
+  'import/prefer-default-export': 'off',
+}
+
+module.exports = { rules }

--- a/packages/eslint-config-globis/rules/react.js
+++ b/packages/eslint-config-globis/rules/react.js
@@ -1,0 +1,10 @@
+const rules = {
+  // FixMe https://github.com/yannickcr/eslint-plugin-react/issues/1846
+  'react/button-has-type': 'off',
+  'react/jsx-filename-extension': ['error', { extensions: ['.tsx'] }],
+  'react/jsx-key': ['error', { checkFragmentShorthand: true }],
+  'react/jsx-props-no-spreading': 'off',
+  'react/prop-types': 'off',
+}
+
+module.exports = { rules }

--- a/packages/eslint-config-globis/rules/typescript.js
+++ b/packages/eslint-config-globis/rules/typescript.js
@@ -1,0 +1,24 @@
+const rules = {
+  '@typescript-eslint/consistent-type-definitions': ['error', 'type'],
+  '@typescript-eslint/explicit-function-return-type': 'off',
+  '@typescript-eslint/explicit-member-accessibility': 'off',
+  '@typescript-eslint/explicit-module-boundary-types': 'off',
+  '@typescript-eslint/no-unused-vars': [
+    'error',
+    {
+      vars: 'all',
+      args: 'all',
+      ignoreRestSiblings: false,
+      argsIgnorePattern: '^_',
+    },
+  ],
+  '@typescript-eslint/unbound-method': 'off',
+}
+
+const configFileRules = {
+  '@typescript-eslint/no-floating-promises': 'off',
+  '@typescript-eslint/no-unsafe-assignment': 'off',
+  '@typescript-eslint/no-unsafe-call': 'off',
+}
+
+module.exports = { rules, configFileRules }

--- a/packages/eslint-config-globis/shared.js
+++ b/packages/eslint-config-globis/shared.js
@@ -1,62 +1,34 @@
-// ruleset for JavaScript and TypeScript
-const baseRules = {
-  // FixMe https://github.com/benmosher/eslint-plugin-import/issues/1615
-  'import/extensions': [
-    'error',
-    'ignorePackages',
-    {
-      js: 'never',
-      jsx: 'never',
-      mjs: 'never',
-      ts: 'never',
-      tsx: 'never',
-    },
-  ],
-  'import/order': ['error', { 'newlines-between': 'always' }],
-  'import/prefer-default-export': 'off',
-}
+const { rules: baseRules } = require('./rules/base')
+const {
+  rules: baseTypeScriptRules,
+  configFileRules: baseTypeScriptConfigFileRules,
+} = require('./rules/typescript')
 
 module.exports = {
-  extends: ['plugin:prettier/recommended'],
-  rules: {
-    ...baseRules,
-  },
+  rules: { ...baseRules },
   overrides: [
     {
+      // RuleSet for JavaScript
+      files: ['**/*.js', '**/*.jsx'],
+      extends: ['plugin:prettier/recommended'],
+    },
+    {
       // RuleSet for TypeScript
+      files: ['**/*.ts', '**/*.tsx'],
       extends: [
         'plugin:@typescript-eslint/recommended',
         'plugin:@typescript-eslint/recommended-requiring-type-checking',
         'plugin:prettier/recommended',
         'prettier/@typescript-eslint',
       ],
-      files: ['**/*.ts', '**/*.tsx'],
-      parser: '@typescript-eslint/parser',
-      plugins: ['@typescript-eslint'],
       rules: {
-        ...baseRules,
-        '@typescript-eslint/consistent-type-definitions': ['error', 'type'],
-        '@typescript-eslint/explicit-function-return-type': 'off',
-        '@typescript-eslint/explicit-member-accessibility': 'off',
-        '@typescript-eslint/explicit-module-boundary-types': 'off',
-        '@typescript-eslint/no-unused-vars': [
-          'error',
-          {
-            vars: 'all',
-            args: 'all',
-            ignoreRestSiblings: false,
-            argsIgnorePattern: '^_',
-          },
-        ],
-        '@typescript-eslint/unbound-method': 'off',
+        ...baseTypeScriptRules,
       },
       overrides: [
         {
           files: ['**/*.config.*', '**/*.spec.*', '.storybook/**/*'],
           rules: {
-            '@typescript-eslint/no-floating-promises': 'off',
-            '@typescript-eslint/no-unsafe-assignment': 'off',
-            '@typescript-eslint/no-unsafe-call': 'off',
+            ...baseTypeScriptConfigFileRules,
           },
         },
       ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -266,7 +266,7 @@
     eslint-scope "^5.0.0"
     eslint-utils "^2.0.0"
 
-"@typescript-eslint/parser@4.1.0":
+"@typescript-eslint/parser@4.1.0", "@typescript-eslint/parser@^4.0.1":
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.1.0.tgz#9b0409411725f14cd7faa81a664e5051225961db"
   integrity sha512-hM/WNCQTzDHgS0Ke3cR9zPndL3OTKr9OoN9CL3UqulsAjYDrglSwIIgswSmHBcSbOzLmgaMARwrQEbIumIglvQ==
@@ -1165,7 +1165,16 @@ eslint-config-airbnb-base@^14.2.0:
     object.assign "^4.1.0"
     object.entries "^1.1.2"
 
-eslint-config-airbnb@18.2.0:
+eslint-config-airbnb-typescript@10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-airbnb-typescript/-/eslint-config-airbnb-typescript-10.0.0.tgz#fb0b307de31ce9465d706e987590da0f0f594f81"
+  integrity sha512-me2QQj+MUc9+vsr44ZMgGdI2f7Brd7dWTl/+ly9r5RFsoSPkwzV/N4tTg5ZOrtA4Ay18urKPKmwLGe9TTIDxnw==
+  dependencies:
+    "@typescript-eslint/parser" "^4.0.1"
+    eslint-config-airbnb "^18.2.0"
+    eslint-config-airbnb-base "^14.2.0"
+
+eslint-config-airbnb@^18.2.0:
   version "18.2.0"
   resolved "https://registry.yarnpkg.com/eslint-config-airbnb/-/eslint-config-airbnb-18.2.0.tgz#8a82168713effce8fc08e10896a63f1235499dcd"
   integrity sha512-Fz4JIUKkrhO0du2cg5opdyPKQXOI2MvF8KUvN2710nJMT6jaRUpRE2swrJftAjVGL7T1otLM5ieo5RqS1v9Udg==


### PR DESCRIPTION
## TL;DR

- 各プロダクトのTypeScript v4 x ESLint対応向けにConfigを見直しました
- Linterの基盤を `eslint-config-airbnb` から `eslint-config-airbnb-typescript` に変更
	- 雑に言うと、この恩恵に乗りたい。自前でやりたくない
	- https://github.com/iamturns/eslint-config-airbnb-typescript/blob/master/lib/shared.js#L25-L203
- `.jsx | .js` と `.tsx | .ts` で適用RuleをSwitchさせてます

## Check list

- [x] Pass CI

## How to Check

1. 当PRをローカルにcheckout
1. 利用したいプロジェクトルートで `yarn add ../path/to/eslint-config-globis -D` する
1. `yarn lint` を実行