### PR TITLE
chore: reconfigure renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,21 +12,21 @@
   ],
   "packageRules": [
     {
-      "packagePatterns": [
+      "matchPackagePatterns": [
         "*"
       ]
     },
     {
-      "depTypeList": [
+      "groupName": "dependencies",
+      "matchDepTypes": [
         "dependencies"
-      ],
-      "groupName": "dependencies"
+      ]
     },
     {
-      "depTypeList": [
+      "groupName": "devDependencies",
+      "matchDepTypes": [
         "devDependencies"
-      ],
-      "groupName": "devDependencies"
+      ]
     }
   ],
   "reviewers": [


### PR DESCRIPTION
## TL;DR
- `renovate-config-validator` でconfigの古い書き方から新しい書き方へ変更しました

refs:
https://docs.renovatebot.com/reconfigure-renovate/


```shell
❯ npx --package renovate -c 'renovate-config-validator'
 INFO: Validating renovate.json
 WARN: Config migration necessary
       "oldConfig": {
         "extends": ["config:base", ":pinAllExceptPeerDependencies"],
         "automerge": true,
         "lockFileMaintenance": {"enabled": true},
         "ignoreDeps": ["husky"],
         "packageRules": [
           {"packagePatterns": ["*"]},
           {"depTypeList": ["dependencies"], "groupName": "dependencies"},
           {"depTypeList": ["devDependencies"], "groupName": "devDependencies"}
         ],
         "reviewers": ["team:jser"],
         "vulnerabilityAlerts": {"enabled": true}
       },
       "newConfig": {
         "extends": ["config:base", ":pinAllExceptPeerDependencies"],
         "automerge": true,
         "lockFileMaintenance": {"enabled": true},
         "ignoreDeps": ["husky"],
         "packageRules": [
           {"matchPackagePatterns": ["*"]},
           {"groupName": "dependencies", "matchDepTypes": ["dependencies"]},
           {"groupName": "devDependencies", "matchDepTypes": ["devDependencies"]}
         ],
         "reviewers": ["team:jser"],
         "vulnerabilityAlerts": {"enabled": true}
       }
 INFO: Config validated successfully
```


## How to check

## Check list
- [ ] pass CI