### PR TITLE
Update renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,6 @@
     "config:base",
     ":pinAllExceptPeerDependencies"
   ],
-  "automerge": true,
   "lockFileMaintenance": {
     "enabled": true
   },


### PR DESCRIPTION
## TL;DR

- `reviewers` したものの動いてない

> When automerge is enabled on a PR, Renovate will not add assignees or reviewers at PR creation time
https://docs.renovatebot.com/automerge-configuration/#assignees-and-reviewers

🙏  ごめんて

## Check list

- [x] Renovate Docをさらっと読み直してほしいかも。。。