### PR TITLE
fix: Turn off require-default-props

### DIFF
--- a/packages/eslint-config-globis/rules/react.js
+++ b/packages/eslint-config-globis/rules/react.js
@@ -5,6 +5,7 @@ const rules = {
   'react/jsx-key': ['error', { checkFragmentShorthand: true }],
   'react/jsx-props-no-spreading': 'off',
   'react/prop-types': 'off',
+  'react/require-default-props': 'off',
 }
 
 module.exports = { rules }


### PR DESCRIPTION
- 以下の理由によりoffにします
  - PropTypes の利用は基本的にしていないため
  - React.FC の利用をやめる際に、このルールによって怒られるため

参考：https://www.notion.so/globisorg/React-FC-50a0c5dca41f4088b9d20e384786eb74

close: https://github.com/globis-org/frontend-standard/issues/235