### PR TITLE
fix: ESLint based on airbnb

### DIFF
--- a/packages/eslint-config-globis/index.js
+++ b/packages/eslint-config-globis/index.js
@@ -13,7 +13,7 @@ module.exports = {
     {
       // RuleSet for TypeScript
       files: ['**/*.ts', '**/*.tsx'],
-      extends: ['airbnb-typescript', 'airbnb/hooks', './shared.js'],
+      extends: ['airbnb', 'airbnb-typescript', 'airbnb/hooks', './shared.js'],
       rules: {
         ...reactRules,
       },


### PR DESCRIPTION
## TL;DR

- airbnbをベースとするためのextendsが抜けていたため修正しました

ref: https://github.com/iamturns/eslint-config-airbnb-typescript#3-configure-eslint


## Check list
- [ ] pass CI