### PR TITLE
chore: Add a trigger for shipjs manual prepare

### DIFF
--- a/.github/workflows/shipjs-manual-prepare.yml
+++ b/.github/workflows/shipjs-manual-prepare.yml
@@ -1,5 +1,7 @@
 name: Ship js Manual Prepare
-on: deployment
+on:
+  deployment:
+  workflow_dispatch:
 jobs:
   manual_prepare:
     runs-on: Ubuntu-latest


### PR DESCRIPTION
Added a trigger for `shipjs-manual-trigger` github actions

補足
デプロイ作業で`shipjs-manual-trigger`をGitHub上から動かすようにするため